### PR TITLE
[bitrate] fix BSOD in drivers not support bitrate

### DIFF
--- a/plugin/bitrate.py
+++ b/plugin/bitrate.py
@@ -86,8 +86,11 @@ class Bitrate:
 			if len(line):
 				self.datalines.append(line)
 		if len(self.datalines) >= 2:
-			self.vmin, self.vmax, self.vavg, self.vcur = self.datalines[0].split(' ')
-			self.amin, self.amax, self.aavg, self.acur = self.datalines[1].split(' ')
+			try:
+				self.vmin, self.vmax, self.vavg, self.vcur = self.datalines[0].split(' ')
+				self.amin, self.amax, self.aavg, self.acur = self.datalines[1].split(' ')
+			except:
+				self.clearValues()
 			self.datalines = []
 			if self.refresh_func:
 				self.refresh_func()


### PR DESCRIPTION
<  3618.246>   File
"/usr/lib/enigma2/python/Plugins/Extensions/Bitrate/bitrate.py", line
89, in dataAvail
<  3618.247>     self.vmin, self.vmax, self.vavg,
self.vcur = self.datalines[0].split(' ')
<  3618.247> ValueError: too
many values to unpack
